### PR TITLE
Setting the SFTP user's home directory to be executable

### DIFF
--- a/sftp-to-s3/entrypoint
+++ b/sftp-to-s3/entrypoint
@@ -25,7 +25,7 @@ export AWSSECRETACCESSKEY=$AWS_SECRET_KEY
 
 mkdir -p /home/$FTP_USER
 chown root:root /home/$FTP_USER
-chmod 744 /home/$FTP_USER
+chmod 745 /home/$FTP_USER
 
 mkdir -p /home/$FTP_USER/s3
 s3fs $S3_BUCKET /home/$FTP_USER/s3  -o nosuid,nonempty,nodev,allow_other,retries=5


### PR DESCRIPTION
This allows them to enter the chroot jail automatically on login. Otherwise I get errors like this when I log in with SFTP and try to upload a file named "foo.txt":

sftp> put foo.txt
Uploading foo.txt to /s3/foo.txt
remote open(/s3/foo.txt): Permission denied

No worries if you don't want this change. This Dockerfile is great and saved me a lot of time, so I thought I'd take the time to share this tiny change that makes it work for me right out of the box!